### PR TITLE
Fixes Home Assistant Core 0.110 warning

### DIFF
--- a/custom_components/philips_android_tv/media_player.py
+++ b/custom_components/philips_android_tv/media_player.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from datetime import timedelta
 from homeassistant.components.media_player import (
-    MediaPlayerDevice, PLATFORM_SCHEMA
+    MediaPlayerEntity, PLATFORM_SCHEMA
 )
 from homeassistant.components.media_player.const import (
     SUPPORT_STOP, SUPPORT_PLAY, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,
@@ -76,7 +76,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([PhilipsTV(tvapi, name, mac)])
 
 
-class PhilipsTV(MediaPlayerDevice):
+class PhilipsTV(MediaPlayerEntity):
     """Representation of a 2016+ Philips TV exposing the JointSpace API."""
 
     def __init__(self, tv, name, mac):


### PR DESCRIPTION
This change simply renames the `MediaPlayerDevice` to `MediaPlayerEntity`
as it was renamed with the release of Home Assistant core 0.110. See also:
[62bc02fddaecd07a716bef6b0ecd2d3295781fb9#diff-5611ccdb60e42595186058f82df9c7a8](https://github.com/home-assistant/core/commit/62bc02fddaecd07a716bef6b0ecd2d3295781fb9#diff-5611ccdb60e42595186058f82df9c7a8)