### PR TITLE
added compatibility with pus7304 models

### DIFF
--- a/custom_components/philips_android_tv/media_player.py
+++ b/custom_components/philips_android_tv/media_player.py
@@ -472,8 +472,10 @@ class PhilipsTVBase(object):
     def get_state(self):
         r = self._get_req('powerstate')
         if r:
+            self.api_online = True
             self.on = r['powerstate'] == 'On'
         else:
+            self.api_online = False
             self.on = False
 
     def get_audiodata(self):

--- a/custom_components/philips_android_tv/media_player.py
+++ b/custom_components/philips_android_tv/media_player.py
@@ -125,7 +125,10 @@ class PhilipsTV(MediaPlayerEntity):
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
-        return self._volume / self._max_volume
+        if self._volume is None or self._max_volume is None:
+            return 0
+        else:
+            return self._volume / self._max_volume
 
     @property
     def is_volume_muted(self):
@@ -274,7 +277,10 @@ class PhilipsTV(MediaPlayerEntity):
             elif self._media_cont_type == 'app':
                 self._state = STATE_IDLE
         else:
-            self._state = STATE_OFF
+            if self._api_online:
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_UNKNOWN
 
 
 class PhilipsTVBase(object):


### PR DESCRIPTION
Fixes #32 

I've found a workaround for this models that have sometimes some connectivity issues.

In this case when a tv lacks connections it sets the status to *unknown* instead of *off* so any automation about this status can be set specifically when the status changes to *on* from *off* and discarding connection drops.

May be also helpful for other models where the network is not stable.