### PR TITLE
improve wol by refreshing api

### DIFF
--- a/custom_components/philips_android_tv/media_player.py
+++ b/custom_components/philips_android_tv/media_player.py
@@ -150,6 +150,7 @@ class PhilipsTV(MediaPlayerEntity):
             _LOGGER.info("Sending WOL [try #%s]", i)
             self.wol()
             time.sleep(3)
+            self.update()
             self._tv.set_power_state('On')
             i += 1
         if not self._api_online:


### PR DESCRIPTION
Even if my TV turns on and api is reachable, the check does not know about it as the property `self._api_online` does not necessarily get's updated (within HAs throttled main thread) while checking.

This change does enforce an update so the while loop does know about the changes.